### PR TITLE
fix: resolve conflict

### DIFF
--- a/stream8-devel/Dockerfile
+++ b/stream8-devel/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf module enable -y python38:3.8 \
     bind-utils yum-utils sshpass make gcc gcc-c++ \
     openssl-devel bzip2-devel libffi-devel zlib-devel \
     rpm-build rpmdevtools rpm-sign rpmlint systemd \
-    coreutils diffutils patch rpm-devel python39 \
+    diffutils patch rpm-devel python39 \
   && dnf config-manager --set-enabled powertools \
   && dnf update -y \
   && rm -r -f /var/cache/*


### PR DESCRIPTION
remove coreutils

fixes:
``` bash
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-15.el8.x86_64 from @System
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-10.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-12.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-13.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-14.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-15.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-8.el8.x86_64 from baseos
5.169   - package coreutils-8.30-15.el8.x86_64 from baseos conflicts with coreutils-single provided by coreutils-single-8.30-9.el8.x86_64 from baseos
5.169   - cannot install the best candidate for the job
5.169 (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```